### PR TITLE
Fixed an issue with old IE running VideoJS with Flash on slow computers

### DIFF
--- a/js/bigvideo.js
+++ b/js/bigvideo.js
@@ -193,11 +193,15 @@
 			isPlaying = true;
 			if (isAmbient) {
 				$('#big-video-control-container').css('display','none');
-				player.volume(0);
+				player.ready(function(){
+					player.volume(0);
+				});
 				doLoop = true;
 			} else {
 				$('#big-video-control-container').css('display','block');
-				player.volume(defaultVolume);
+				player.ready(function(){
+					player.volume(defaultVolume);
+				});
 				doLoop = false;
 			}
 			$('#big-video-image').css('display','none');


### PR DESCRIPTION
When the player is in Flash mode (NOT HTML5) the volume API will not work until Flash is initialized.
This could happen on slow computers running old IE (but also Firefox < 4.0).
