### PR TITLE
Add onShown callback

### DIFF
--- a/lib/bigvideo.js
+++ b/lib/bigvideo.js
@@ -321,12 +321,14 @@
 						source = options.altSource;
 					}
 					playVideo(source);
+					options.onShown && options.onShown();
 					isQueued = false;
 				}
 			} else {
 				playlist = source;
 				currMediaIndex = 0;
 				playVideo(playlist[currMediaIndex]);
+				options.onShown && options.onShown();
 				isQueued = true;
 			}
 		};


### PR DESCRIPTION
Allow onShown callback to be passed to BV.show(). To be used for hiding overlays until video is shown.
