### PR TITLE
use dom traversal for element selection to allow multiple videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<html>
+<body>
+	<div class="video" data-video="http://vjs.zencdn.net/v/oceans.mp4"></div>
+	<div class="video" data-video="http://vjs.zencdn.net/v/oceans.mp4"></div>
+	<script src="bower_components/requirejs/require.js"></script>
+	<script>
+		require.config({
+			paths: {
+				"BigVideo": "lib/bigvideo",
+				"jquery": "bower_components/jquery/dist/jquery",
+				"jquery-ui": "bower_components/jquery-ui/ui/jquery-ui",
+				"videojs": "bower_components/video.js/dist/video-js/video",
+				"imagesloaded": "bower_components/imagesloaded/imagesloaded",
+				"eventEmitter/EventEmitter": "bower_components/eventEmitter/EventEmitter",
+				"eventie/eventie": "bower_components/eventie/eventie"
+			},
+			shim: {
+				"videojs": {exports: 'videojs'}
+			}
+		});
+		require(['BigVideo'], function(bigvideo) {
+
+			$('.video').bigvideo().bigvideo('init').bigvideo('show');
+
+
+		});
+	</script>
+</body>
+</html>

--- a/lib/bigvideo.js
+++ b/lib/bigvideo.js
@@ -32,7 +32,7 @@
 			forceAutoplay:false,
 			controls:false,
 			doLoop:false,
-			container:$(element) || $('body'),
+			container: element ? $(element) : $('body'),
 			shrinkable:false
 		};
 


### PR DESCRIPTION
I needed to run multiple for a project. Figured I'd contribute back.
With this it uses the container's children to add and refer to elements rather than id's.
Also threw in a jQuery helper function to allow $('.video').bigvideo().bigvideo('init').bigvideo('show');
It also uses data-video on elements to load that video.
