### PR TITLE
Refactored BigVideo.show method and ...

### DIFF
--- a/lib/bigvideo.js
+++ b/lib/bigvideo.js
@@ -328,30 +328,68 @@
 			}
 		};
 
+		/**
+		 * Show video or image file
+		 *
+		 * @param source: The file to show, can be:
+		 * 		- an array with objects for video files types
+		 *		- a string to a single video file
+		 * 		- a string to a image file
+		 * @param options: An object with those possible attributes:
+		 *		- boolean "ambient" to set video to loop
+		 *		- function onShown
+		 */
 		BigVideo.show = function(source,options) {
 			if (options === undefined) options = {};
 			isAmbient = options.ambient === true;
 			if (isAmbient || options.doLoop) settings.doLoop = true;
+
 			if (typeof(source) === 'string') {
+				// if input was a string, try show that image or video
 				var ext = source.substring(source.lastIndexOf('.')+1);
 				if (ext === 'jpg' || ext === 'gif' || ext === 'png') {
 					showPoster(source);
-				} else {
-					if (options.altSource && navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-						source = options.altSource;
-					}
+				} else if (ext === 'mp4', 'ogg', 'ogv', 'webm') {
 					playVideo(source);
 					if (options.onShown) options.onShown();
 					isQueued = false;
 				}
+			} else if ($.isArray(source)) {
+				// if the input was an array, pass it to videojs
+				playVideo(source);
+			} else if (typeof(source) === "object" && source.src && source.type) {
+				// if the input was an object with valid attributes, wrap it in an 
+				// array and pass it to videojs
+				playVideo([source]);
 			} else {
-				playlist = source;
-				currMediaIndex = 0;
-				playVideo(playlist[currMediaIndex]);
-				if (options.onShown) options.onShown();
-				isQueued = true;
+				// fail without valid input
+				throw("BigVideo.show received invalid input for parameter source");
 			}
 		};
+
+		/**
+		 * Show a playlist of video files
+		 *
+		 * @param files: array of elements to pass to BigVideo.show in sequence
+		 * @param options: An object with those possible attributes:
+		 *		- boolean "ambient" to set video to loop
+		 *		- function onShown
+		 */
+		BigVideo.showPlaylist = function (files, options) {
+			if (!$.isArray(files)) {
+				throw("BigVideo.showPlaylist parameter files accepts only arrays");
+			}
+
+			if (options === undefined) options = {};
+			isAmbient = options.ambient === true;
+			if (isAmbient || options.doLoop) settings.doLoop = true;
+
+			playlist = files;
+			currMediaIndex = 0;
+			this.show(playlist[currMediaIndex]);
+			if (options.onShown) options.onShown();
+			isQueued = true;
+		}
 
 		// Expose Video.js player
 		BigVideo.getPlayer = function() {


### PR DESCRIPTION
separated playlist playback to BigVi...deo.showPlaylist

BigVideo.show now accepts source as an array of video object with parameters type and src, like videoJS natively accepts them.

Playlist playback is now accessible only via BigVideo.showPlaylist

NOTE:
- While this is not a breaking change, if users supplied only a video string to BigVideo.show it does change quite a bit of functionality
- The playlist functionality has been moved to its own function
- I haven't updated documentation pending feedback
