### PR TITLE
Removes query string variables from the URI

### DIFF
--- a/lib/bigvideo.js
+++ b/lib/bigvideo.js
@@ -347,7 +347,7 @@
 
 			if (typeof(source) === 'string') {
 				// if input was a string, try show that image or video
-				var ext = source.substring(source.lastIndexOf('.')+1);
+				var ext = ( source.lastIndexOf('?') > 0 ) ? source.substring(source.lastIndexOf('.')+1, source.lastIndexOf('?')) : source.substring( source.lastIndexOf('.')+1);
 				if (ext == 'jpg' || ext == 'gif' || ext == 'png') {
 					showPoster(source);
 				} else if (ext == 'mp4' || ext == 'ogg' || ext == 'ogv'|| ext == 'webm') {


### PR DESCRIPTION
Vimeo seems to have added these in; now it chokes up BV's loader, unless you wipe whatever comes after the question mark. This checks to see if one exists, then it removes 'em if they do.
