### PR TITLE
added height=1 width=1 to video tag

### DIFF
--- a/lib/bigvideo.js
+++ b/lib/bigvideo.js
@@ -261,7 +261,7 @@
 				// create player
 				settings.container.prepend(wrap);
 				var autoPlayString = settings.forceAutoplay ? 'autoplay' : '';
-				player = $('<video id="'+vidEl.substr(1)+'" class="video-js vjs-default-skin" preload="auto" data-setup="{}" '+autoPlayString+' webkit-playsinline></video>');
+				player = $('<video id="'+vidEl.substr(1)+'" class="video-js vjs-default-skin" height="1" width="1" preload="auto" data-setup="{}" '+autoPlayString+' webkit-playsinline></video>');
 				player.css('position','absolute');
 				wrap.append(player);
 


### PR DESCRIPTION
Hi, 
I was facing an issue, we have added a background to the body, and when BigVideo Init() was called and video file is not loaded the black box was showing in right upper corner. this is due to not height and width given to videojs, if not height width is given videojs applies a default height width. I have added height=1 and width=1 now it is only 1px dot. not visible easily. 
![screenshot from 2014-09-10 11 04 06](https://cloud.githubusercontent.com/assets/2954597/4213204/9c9983ea-38b0-11e4-9be2-782f3cf0e631.png)
